### PR TITLE
Check banned update chars not in placements

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,12 @@ NUM_CHARS = 5
 
 
 # Updates the list of banned characters
-def update_banned_characters(banned_chars: list) -> list:
+def update_banned_characters(banned_chars: list, placements: str) -> list:
     try:
         print("Enter characters combined as a string")
         element = input()
         for i in element:
-            if i.isalpha() and i not in banned_chars:
+            if i.isalpha() and i not in banned_chars and i not in placements:
                 banned_chars.append(i.lower())
         print("Enter 0 to ignore, 1 to continue")
         stop = int(input())
@@ -140,7 +140,7 @@ def main():
             0 to terminate program""")
             action = int(input())
             if action == 1:
-                banned_characters = update_banned_characters(banned_characters)
+                banned_characters = update_banned_characters(banned_characters, placements)
             elif action == 2:
                 placements = update_placements(banned_characters)
             elif action == 3:


### PR DESCRIPTION
If user inputs a character that is in placements into banned characters, throws everything off (returns 0 results)

This is intended behavior, but wordle returns black if a character is already used, so user might input this

Need to catch and make sure not adding banned char when it is not actually banned